### PR TITLE
Add MDX-driven updates hub and automatic changelog pages

### DIFF
--- a/app/updates/[project]/[version]/page.tsx
+++ b/app/updates/[project]/[version]/page.tsx
@@ -1,0 +1,124 @@
+import fs from "node:fs/promises"
+
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { compileMDX } from "next-mdx-remote/rsc"
+import { remarkHeadingId } from "remark-custom-heading-id"
+import rehypePrettyCode from "rehype-pretty-code"
+import remarkGfm from "remark-gfm"
+import remarkFlexibleCodeTitles from "remark-flexible-code-titles"
+import rehypeExternalLinks from "rehype-external-links"
+import rehypeAutolinkHeadings from "rehype-autolink-headings"
+import remarkDirective from "remark-directive"
+
+import { FooterBars } from "@/components/ui/footer-bars"
+import { getUpdateProjectById, type UpdateProjectId } from "@/lib/updates-config"
+import {
+  getAllUpdateParams,
+  getUpdateEntry,
+  type UpdateFrontmatter,
+} from "@/lib/updates.server"
+import { useMDXComponents as getMDXComponents } from "@/mdx-components"
+
+export const dynamicParams = false
+
+type UpdatePageProps = {
+  params: Promise<{ project: string; version: string }>
+}
+
+export async function generateStaticParams() {
+  return getAllUpdateParams()
+}
+
+export async function generateMetadata({ params }: UpdatePageProps): Promise<Metadata> {
+  const { project, version } = await params
+  const projectConfig = getUpdateProjectById(project)
+
+  if (!projectConfig) {
+    return { title: "Update | Subway Builder Modded" }
+  }
+
+  const entry = await getUpdateEntry(project as UpdateProjectId, version)
+
+  return {
+    title: entry?.frontmatter.title
+      ? `${entry.frontmatter.title} | ${projectConfig.label} | Subway Builder Modded`
+      : `${projectConfig.label} Update | Subway Builder Modded`,
+    description: entry?.frontmatter.summary ?? `Release notes for ${projectConfig.label}.`,
+  }
+}
+
+export default async function UpdateVersionPage({ params }: UpdatePageProps) {
+  const { project, version } = await params
+  const projectConfig = getUpdateProjectById(project)
+  if (!projectConfig) notFound()
+
+  const entry = await getUpdateEntry(project as UpdateProjectId, version)
+  if (!entry) notFound()
+
+  const source = await fs.readFile(entry.filePath, "utf8")
+
+  const { content, frontmatter } = await compileMDX<UpdateFrontmatter>({
+    source,
+    options: {
+      parseFrontmatter: true,
+      mdxOptions: {
+        remarkPlugins: [remarkGfm, remarkHeadingId, remarkFlexibleCodeTitles, remarkDirective],
+        rehypePlugins: [
+          [
+            rehypePrettyCode,
+            {
+              theme: "github-dark",
+              keepBackground: false,
+            },
+          ],
+          [
+            rehypeExternalLinks,
+            {
+              target: "_blank",
+              rel: ["nofollow", "noopener", "noreferrer"],
+            },
+          ],
+          [
+            rehypeAutolinkHeadings,
+            {
+              behavior: "append",
+              properties: {
+                className: ["heading-anchor"],
+                ariaLabel: "Link to section",
+              },
+              content: {
+                type: "text",
+                value: "#",
+              },
+            },
+          ],
+        ],
+      },
+    },
+    components: getMDXComponents(),
+  })
+
+  return (
+    <main className="px-7 py-8">
+      <article className="mx-auto max-w-3xl">
+        <Link
+          href={`/updates/${projectConfig.id}`}
+          className="mb-5 inline-flex text-sm font-semibold text-muted-foreground hover:text-foreground"
+        >
+          ← Back to {projectConfig.label}
+        </Link>
+
+        <header className="mb-8 border-b border-border pb-5" style={{ borderColor: `${projectConfig.accent}66` }}>
+          <h1 className="text-4xl font-black tracking-tight" style={{ color: projectConfig.base }}>{frontmatter.title ?? entry.version}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{frontmatter.date}</p>
+        </header>
+
+        <div className="max-w-none space-y-1">{content}</div>
+      </article>
+
+      <FooterBars className="mt-8" />
+    </main>
+  )
+}

--- a/app/updates/[project]/page.tsx
+++ b/app/updates/[project]/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+
+import { UpdateStatusBadge } from "@/components/updates/update-status-badge"
+import { Card } from "@/components/ui/card"
+import { FooterBars } from "@/components/ui/footer-bars"
+import {
+  UPDATE_PROJECTS,
+  getUpdateProjectById,
+  type UpdateProjectId,
+} from "@/lib/updates-config"
+import { getUpdatesForProject } from "@/lib/updates.server"
+
+type ProjectPageProps = {
+  params: Promise<{ project: string }>
+}
+
+export async function generateMetadata({ params }: ProjectPageProps): Promise<Metadata> {
+  const { project } = await params
+  const projectConfig = getUpdateProjectById(project)
+
+  if (!projectConfig) {
+    return { title: "Updates | Subway Builder Modded" }
+  }
+
+  return {
+    title: `${projectConfig.label} Changelogs | Subway Builder Modded`,
+    description: projectConfig.description,
+  }
+}
+
+export async function generateStaticParams() {
+  return UPDATE_PROJECTS.map((project) => ({ project: project.id }))
+}
+
+export default async function ProjectUpdatesPage({ params }: ProjectPageProps) {
+  const { project } = await params
+  const projectConfig = getUpdateProjectById(project)
+  if (!projectConfig) notFound()
+
+  const updates = await getUpdatesForProject(project as UpdateProjectId)
+
+  return (
+    <main className="px-7 py-8">
+      <div className="mx-auto max-w-5xl">
+        <Link
+          href="/updates"
+          className="mb-6 inline-flex text-sm font-semibold text-muted-foreground hover:text-foreground"
+        >
+          ← Back to updates
+        </Link>
+
+        <header className="mb-9 text-center">
+          <h1
+            className="text-4xl font-black tracking-tight sm:text-5xl"
+            style={{ color: projectConfig.base }}
+          >
+            {projectConfig.label} Changelogs
+          </h1>
+          <p className="mt-3 text-lg text-muted-foreground">
+            Releases are generated automatically from files in <code>content/updates/{projectConfig.id}</code>.
+          </p>
+        </header>
+
+        <section className="space-y-4">
+          {updates.map((update, index) => (
+            <Link
+              key={update.slug}
+              href={`/updates/${projectConfig.id}/${update.slug}`}
+              className="block outline-none"
+            >
+              <Card
+                className="flex items-center justify-between gap-4 border p-4 transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-white/5"
+                style={{
+                  borderColor: `${projectConfig.accent}66`,
+                  backgroundColor: `${projectConfig.base}12`,
+                }}
+              >
+                <div>
+                  <h2
+                    className="text-2xl font-extrabold tracking-tight"
+                    style={{ color: projectConfig.base }}
+                  >
+                    {update.frontmatter.title || update.version}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">{update.frontmatter.date}</p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {index === 0 ? <UpdateStatusBadge tag="latest" /> : null}
+                  <UpdateStatusBadge tag={update.frontmatter.tag ?? "release"} />
+                </div>
+              </Card>
+            </Link>
+          ))}
+        </section>
+      </div>
+
+      <FooterBars className="mt-8" />
+    </main>
+  )
+}

--- a/app/updates/page.tsx
+++ b/app/updates/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+
+import { Card } from "@/components/ui/card"
+import { FooterBars } from "@/components/ui/footer-bars"
+import { LineBullet } from "@/components/ui/line-bullet"
+import { UPDATE_PROJECTS } from "@/lib/updates-config"
+
+export const metadata: Metadata = {
+  title: "Updates & Changelogs | Subway Builder Modded",
+  description:
+    "Browse release notes and changelogs for Subway Builder Modded projects.",
+}
+
+export default function UpdatesHubPage() {
+  return (
+    <main className="px-7 py-8">
+      <div className="mx-auto max-w-6xl">
+        <header className="mb-10 text-center">
+          <h1 className="text-4xl font-black tracking-tight sm:text-5xl">Updates & Changelogs</h1>
+          <p className="mt-3 text-lg text-muted-foreground">
+            All Subway Builder Modded project releases in one place.
+          </p>
+        </header>
+
+        <section className="grid gap-7 md:grid-cols-2">
+          {UPDATE_PROJECTS.map((project) => {
+            const Icon = project.icon
+
+            return (
+              <Link key={project.id} href={project.href} className="block h-full outline-none">
+                <Card
+                  className="group flex h-full min-h-[22rem] flex-col justify-between border p-6 transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-white/5"
+                  style={{
+                    backgroundColor: project.base,
+                    borderColor: `${project.accent}70`,
+                  }}
+                >
+                  <div>
+                    <div className="mb-6">
+                      <LineBullet
+                        bullet={project.bullet}
+                        color={project.mid}
+                        textColor={project.accent}
+                        size="md"
+                      />
+                    </div>
+
+                    <div className="mb-5 flex items-center gap-3">
+                      <Icon className="size-5" style={{ color: project.accent }} />
+                      <h2 className="text-3xl font-black" style={{ color: project.accent }}>
+                        {project.label}
+                      </h2>
+                    </div>
+
+                    <p className="text-base leading-relaxed" style={{ color: `${project.accent}DD` }}>
+                      {project.description}
+                    </p>
+                  </div>
+
+                  <div className="mt-8 inline-flex items-center gap-2 text-sm font-semibold" style={{ color: project.accent }}>
+                    View changelogs
+                    <ArrowRight className="size-4" />
+                  </div>
+                </Card>
+              </Link>
+            )
+          })}
+        </section>
+      </div>
+
+      <FooterBars className="mt-8" />
+    </main>
+  )
+}

--- a/components/updates/update-section-heading.tsx
+++ b/components/updates/update-section-heading.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react"
+import { LineBullet } from "@/components/ui/line-bullet"
+import { cn } from "@/lib/utils"
+
+type UpdateSectionHeadingProps = {
+  bullet: string
+  color?: string
+  textColor?: string
+  children: ReactNode
+  className?: string
+}
+
+export function UpdateSectionHeading({
+  bullet,
+  color = "#0C493B",
+  textColor = "#E3E3E3",
+  children,
+  className,
+}: UpdateSectionHeadingProps) {
+  return (
+    <div className={cn("mt-10 flex items-center gap-3", className)}>
+      <LineBullet bullet={bullet} color={color} textColor={textColor} shape="circle" size="sm" />
+      <h2 className="m-0 text-xl font-extrabold tracking-wide uppercase">{children}</h2>
+      <span className="h-px flex-1 bg-border" />
+    </div>
+  )
+}

--- a/components/updates/update-status-badge.tsx
+++ b/components/updates/update-status-badge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import type { UpdateTag } from "@/lib/updates-config"
+
+type UpdateStatusBadgeProps = {
+  tag: UpdateTag | "latest"
+  className?: string
+}
+
+const STYLE_BY_TAG = {
+  latest: "bg-blue-600 text-white dark:bg-blue-500",
+  release: "bg-emerald-600 text-white dark:bg-emerald-500",
+  beta: "bg-amber-400 text-black dark:bg-amber-300",
+} satisfies Record<UpdateStatusBadgeProps["tag"], string>
+
+export function UpdateStatusBadge({ tag, className }: UpdateStatusBadgeProps) {
+  return (
+    <Badge className={cn("uppercase tracking-wide", STYLE_BY_TAG[tag], className)}>
+      {tag}
+    </Badge>
+  )
+}

--- a/content/updates/railyard/v1.0.0.mdx
+++ b/content/updates/railyard/v1.0.0.mdx
@@ -1,0 +1,15 @@
+---
+title: Railyard - v1.0.0
+date: February 23, 2026
+tag: release
+summary: First public release of Railyard changelog tracking on the new website.
+---
+
+<UpdateSectionHeading bullet="F" color="#ED6D32">Features</UpdateSectionHeading>
+
+- Initial Railyard release notes page in the new MDX-powered updates system.
+- Added centralized project/release browsing at `/updates`.
+
+<UpdateSectionHeading bullet="O" color="#000000">Other Notes</UpdateSectionHeading>
+
+- Additional versions can be added by creating a new file in `content/updates/railyard`.

--- a/content/updates/template-mod/v1.0.0.mdx
+++ b/content/updates/template-mod/v1.0.0.mdx
@@ -1,0 +1,14 @@
+---
+title: Template Mod - v1.0.0
+date: February 18, 2026
+tag: release
+summary: Initial release of the Subway Builder Template Mod.
+---
+
+<UpdateSectionHeading bullet="F" color="#ED6D32">Features</UpdateSectionHeading>
+
+- Initial release.
+
+<UpdateSectionHeading bullet="O" color="#000000">Other Notes</UpdateSectionHeading>
+
+- Documentation is available at [/wiki/template-mod/v1.0/getting-started](/wiki/template-mod/v1.0/getting-started).

--- a/content/updates/template-mod/v1.0.1.mdx
+++ b/content/updates/template-mod/v1.0.1.mdx
@@ -1,0 +1,15 @@
+---
+title: Template Mod - v1.0.1
+date: February 25, 2026
+tag: release
+summary: Follow-up release with polish and fixes for Template Mod.
+---
+
+<UpdateSectionHeading bullet="B" color="#ED6D32">Bugfixes</UpdateSectionHeading>
+
+- Fixed template type exports so generated projects resolve shared utility types correctly.
+- Corrected the default lint script path in scaffolding output.
+
+<UpdateSectionHeading bullet="U" color="#0C493B">Upgrades</UpdateSectionHeading>
+
+- Improved starter comments and inline docs for first-time mod creators.

--- a/lib/updates-config.ts
+++ b/lib/updates-config.ts
@@ -1,0 +1,51 @@
+import { FolderCode, TrainTrack, type LucideIcon } from "lucide-react"
+
+export type UpdateProjectId = "railyard" | "template-mod"
+
+export type UpdateTag = "release" | "beta"
+
+export type UpdateProject = {
+  id: UpdateProjectId
+  label: string
+  description: string
+  href: string
+  repositoryUrl: string
+  icon: LucideIcon
+  bullet: string
+  accent: string
+  base: string
+  mid: string
+}
+
+export const UPDATE_PROJECTS: UpdateProject[] = [
+  {
+    id: "railyard",
+    label: "Railyard",
+    description:
+      "Release notes for the official Subway Builder custom map platform.",
+    href: "/updates/railyard",
+    repositoryUrl: "https://github.com/Subway-Builder-Modded/Railyard",
+    icon: TrainTrack,
+    bullet: "R",
+    accent: "#00D492",
+    base: "#032D23",
+    mid: "#00A97A",
+  },
+  {
+    id: "template-mod",
+    label: "Template Mod",
+    description:
+      "Changelogs for the documented TypeScript template used to build Subway Builder mods.",
+    href: "/updates/template-mod",
+    repositoryUrl: "https://github.com/Subway-Builder-Modded/SubwayBuilderTemplateMod",
+    icon: FolderCode,
+    bullet: "T",
+    accent: "#A684FF",
+    base: "#311362",
+    mid: "#7D52E8",
+  },
+]
+
+export function getUpdateProjectById(id: string) {
+  return UPDATE_PROJECTS.find((project) => project.id === id)
+}

--- a/lib/updates.server.ts
+++ b/lib/updates.server.ts
@@ -1,0 +1,124 @@
+import "server-only"
+
+import fs from "node:fs"
+import path from "node:path"
+import { compileMDX } from "next-mdx-remote/rsc"
+import type { UpdateProjectId, UpdateTag } from "@/lib/updates-config"
+
+const CONTENT_ROOT = path.join(process.cwd(), "content", "updates")
+
+export type UpdateFrontmatter = {
+  title: string
+  date: string
+  summary?: string
+  tag?: UpdateTag
+}
+
+export type UpdateEntry = {
+  projectId: UpdateProjectId
+  version: string
+  slug: string
+  filePath: string
+  frontmatter: UpdateFrontmatter
+}
+
+function exists(filePath: string) {
+  return fs.existsSync(filePath)
+}
+
+function normalizeVersion(version: string) {
+  return version.toLowerCase().startsWith("v") ? version : `v${version}`
+}
+
+function parseSemver(version: string) {
+  const clean = normalizeVersion(version).slice(1)
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(clean)
+  if (!match) return null
+  return match.slice(1).map(Number) as [number, number, number]
+}
+
+function compareVersionsDesc(a: string, b: string) {
+  const aSemver = parseSemver(a)
+  const bSemver = parseSemver(b)
+
+  if (aSemver && bSemver) {
+    for (let i = 0; i < 3; i += 1) {
+      if (aSemver[i] !== bSemver[i]) return bSemver[i] - aSemver[i]
+    }
+    return 0
+  }
+
+  return b.localeCompare(a, undefined, { numeric: true, sensitivity: "base" })
+}
+
+async function readFrontmatter(filePath: string) {
+  const source = await fs.promises.readFile(filePath, "utf8")
+  const { frontmatter } = await compileMDX<UpdateFrontmatter>({
+    source,
+    options: {
+      parseFrontmatter: true,
+    },
+  })
+
+  return frontmatter
+}
+
+export async function getUpdatesForProject(projectId: UpdateProjectId) {
+  const projectDir = path.join(CONTENT_ROOT, projectId)
+  if (!exists(projectDir)) return []
+
+  const entries = await fs.promises.readdir(projectDir, { withFileTypes: true })
+  const updates = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".mdx"))
+      .map(async (entry) => {
+        const slug = entry.name.replace(/\.mdx$/, "")
+        const filePath = path.join(projectDir, entry.name)
+        const frontmatter = await readFrontmatter(filePath)
+
+        return {
+          projectId,
+          version: normalizeVersion(slug),
+          slug,
+          filePath,
+          frontmatter,
+        } satisfies UpdateEntry
+      })
+  )
+
+  return updates.sort((a, b) => compareVersionsDesc(a.version, b.version))
+}
+
+export async function getAllUpdateParams() {
+  const projects = await fs.promises.readdir(CONTENT_ROOT, { withFileTypes: true })
+  const params: { project: string; version: string }[] = []
+
+  for (const project of projects) {
+    if (!project.isDirectory()) continue
+
+    const projectId = project.name as UpdateProjectId
+    const updates = await getUpdatesForProject(projectId)
+
+    for (const update of updates) {
+      params.push({ project: projectId, version: update.slug })
+    }
+  }
+
+  return params
+}
+
+export async function getUpdateEntry(projectId: UpdateProjectId, version: string) {
+  const slug = version.toLowerCase().endsWith(".mdx") ? version.replace(/\.mdx$/, "") : version
+  const filePath = path.join(CONTENT_ROOT, projectId, `${slug}.mdx`)
+  if (!exists(filePath)) return null
+
+  const frontmatter = await readFrontmatter(filePath)
+
+  return {
+    projectId,
+    slug,
+    version: normalizeVersion(slug),
+    filePath,
+    frontmatter,
+  } satisfies UpdateEntry
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -3,6 +3,8 @@ import type { MDXComponents } from "mdx/types"
 import Link from "next/link"
 import { Tabs, TabItem } from "@/components/wiki/mdx-tabs"
 import { WikiCardGrid, WikiCard } from "@/components/wiki/wiki-home-cards"
+import { UpdateSectionHeading } from "@/components/updates/update-section-heading"
+import { UpdateStatusBadge } from "@/components/updates/update-status-badge"
 
 import {
   Admonition,
@@ -121,6 +123,8 @@ const baseComponents: MDXComponents = {
   TabItem,
   WikiCardGrid,
   WikiCard,
+  UpdateSectionHeading,
+  UpdateStatusBadge,
 
   a: MdxLink,
 


### PR DESCRIPTION
### Motivation
- Replace the old, hand-coded updates pages with a single MDX-driven system so changelogs are authored as plain MDX files and discovered automatically.  
- Provide a central `/updates` hub with color-coded project cards and per-project hubs that auto-list releases so maintainers only need to add one file per release.  
- Use site-standard shadcn components for visual parity (badges, line-bullet headings) so update pages match the existing theme.  

### Description
- Add a new updates area under `app/updates` including the landing page (`app/updates/page.tsx`), per-project hub (`app/updates/[project]/page.tsx`), and per-version pages (`app/updates/[project]/[version]/page.tsx`) that render MDX release files.  
- Implement config and server utilities in `lib/updates-config.ts` and `lib/updates.server.ts` to discover `content/updates/<project>/*.mdx`, extract frontmatter, sort versions, and provide `generateStaticParams()` for SSG.  
- Add reusable UI pieces: `components/updates/update-section-heading.tsx` (MDX-friendly line-bullet headings) and `components/updates/update-status-badge.tsx` (shadcn-style `latest`/`release`/`beta` badges).  
- Wire the new components into global MDX mappings (`mdx-components.tsx`) and seed example changelogs in `content/updates/` for `railyard/v1.0.0`, `template-mod/v1.0.0`, and `template-mod/v1.0.1`.  

### Testing
- Ran targeted ESLint on the modified files with `pnpm exec eslint app/updates/page.tsx app/updates/[project]/page.tsx app/updates/[project]/[version]/page.tsx components/updates/update-section-heading.tsx components/updates/update-status-badge.tsx lib/updates-config.ts lib/updates.server.ts mdx-components.tsx`, which completed successfully.  
- Built the site with `pnpm build` and the production build completed and prerendered the new SSG routes successfully.  
- Started a dev server and verified the routes `/updates`, `/updates/template-mod`, and `/updates/template-mod/v1.0.1` loaded correctly and captured screenshots as artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accd8613cc8320883a15a0a8b71372)