### PR TITLE
404 Return Home Button

### DIFF
--- a/app/not-found.test.tsx
+++ b/app/not-found.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import NotFound from '@/app/not-found';
+
+describe('not found page', () => {
+  it('forces the Return Home button to the default color scheme', () => {
+    render(<NotFound />);
+
+    const returnHome = screen.getByRole('link', { name: 'Return Home' });
+    expect(returnHome).toHaveAttribute('data-color-scheme', 'default');
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -59,6 +59,7 @@ export default function NotFound() {
         <div className="mt-7">
           <Link
             href="/"
+            data-color-scheme="default"
             className="inline-flex min-h-10 items-center justify-center rounded-lg border border-border bg-primary px-5 py-2.5 text-sm font-semibold text-primary-foreground transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           >
             Return Home

--- a/content/updates/website/v1.0.2.mdx
+++ b/content/updates/website/v1.0.2.mdx
@@ -53,6 +53,12 @@ description: Changelogs and release notes for the Subway Builder Modded Website 
 </UpdateSection>
 
 <UpdateSection type="bugfixes">
+  #### General
+  <IconList>
+    <IconItem icon="Bug" color="#EF4444">
+      Fixed Return Home button on 404 page inheriting the wrong color scheme
+    </IconItem>
+  </IconList>
   #### Registry
   <IconList>
     <IconItem icon="Bug" color="#EF4444">


### PR DESCRIPTION
Fixed Return Home button on 404 page inheriting the wrong color scheme and added unit test.

Fixes #87.